### PR TITLE
Update guia-instalacion-intellij-idea.mdx

### DIFF
--- a/docs/kotlin/guia-instalacion-intellij-idea.mdx
+++ b/docs/kotlin/guia-instalacion-intellij-idea.mdx
@@ -127,7 +127,7 @@ Seguí la siguiente [guía](http://programacionamartillazos.blogspot.com/2017/07
 Dentro de una terminal ejecutá lo siguiente:
 
 ```bash
-sudo snap install intellij-idea-community -classic
+sudo snap install intellij-idea-community --classic
 ```
 
   </Codigo>


### PR DESCRIPTION
Se corrige comando para instalar desde terminal el IntelliJ IDEA.
Estaba como sudo snap install intellij-idea-community -classic
y se modifica a sudo snap install intellij-idea-community --classic